### PR TITLE
Ignore csrf token field when saving schedule

### DIFF
--- a/src/Http/Controllers/ScheduleController.php
+++ b/src/Http/Controllers/ScheduleController.php
@@ -91,7 +91,7 @@ class ScheduleController extends Controller
     {
         try {
             $schedule = app(config('database-schedule.model'));
-            $schedule->create($request->all());
+            $schedule->create($request->except('_token'));
 
             return redirect()
                 ->action('\RobersonFaria\DatabaseSchedule\Http\Controllers\ScheduleController@index')
@@ -142,7 +142,7 @@ class ScheduleController extends Controller
     public function update(ScheduleRequest $request, Schedule $schedule)
     {
         try {
-            $schedule->update($request->all());
+            $schedule->update($request->except('_token'));
 
             return redirect()
                 ->action('\RobersonFaria\DatabaseSchedule\Http\Controllers\ScheduleController@index')


### PR DESCRIPTION
When i try to save a new schedule, it get the following error:

`Add fillable property [_token] to allow mass assignment on [RobersonFaria\DatabaseSchedule\Models\Schedule].`

Its because of the $request->all() - which contains the csrf _token field.